### PR TITLE
ESLintの修正

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,12 +40,18 @@ const eslintConfig = [
       "react-hooks": reactHooksPlugin,
       prettier: prettierPlugin,
     },
+    settings: {
+      "import/resolver": {
+        typescript: {
+          alwaysTryTypes: true,
+          project: "tsconfig.json",
+        },
+      },
+    },
     rules: {
-      // React rules
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
 
-      // TypeScript rules
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-explicit-any": ["error"],
       "@typescript-eslint/no-unused-vars": [
@@ -55,26 +61,9 @@ const eslintConfig = [
           varsIgnorePattern: "^_",
         },
       ],
-      "@typescript-eslint/naming-convention": [
-        "error",
-        {
-          selector: "variable",
-          format: ["camelCase", "PascalCase"],
-        },
-        {
-          selector: "parameter",
-          format: ["camelCase"],
-        },
-        {
-          selector: "typeLike",
-          format: ["PascalCase"],
-        },
-      ],
 
-      // Prettier rules
       "prettier/prettier": "error",
 
-      // Import rules
       "import/no-unresolved": "error",
       "import/order": [
         "error",
@@ -92,7 +81,12 @@ const eslintConfig = [
               position: "before",
             },
             {
-              pattern: "@/service/**",
+              pattern: "@/features/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/shared/**",
               group: "internal",
               position: "after",
             },
@@ -101,7 +95,6 @@ const eslintConfig = [
         },
       ],
 
-      // React Hooks rules
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
     },


### PR DESCRIPTION
## 関連Issue

- closes #7

## 変更理由

開発において以下の重大なバグが存在していたため修正しました：
- ESLintがimportパスを理解してくれない問題

## 変更内容

### 追加
- TypeScript resolver の設定を追加（alwaysTryTypes と project 指定）
  - ESLintがTypeScriptのパス解決を正しく認識するようになった

### 修正
- `import/order` のパス設定を修正
  - `@/service/**` を `@/features/**` と `@/shared/**` に分離

### 削除
- 過度な `@typescript-eslint/naming-convention` ルール（selector: variable, parameter, typeLike）を削除
- 不要なコメント行を削除（コード可読性向上）

## 変更箇所

- eslint.config.mjs

## 注意事項

- [ ] Lintチェック
- [ ] 動作確認