### PR TITLE
QR再読み込みとroom作成ボタンの作成

### DIFF
--- a/src/features/scan/components/CreateRoomButton.tsx
+++ b/src/features/scan/components/CreateRoomButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/shared/components/ui/button";
+
+export default function CreateRoomButton() {
+  const router = useRouter();
+
+  const handleCreateRoom = () => {
+    // UUID v4を生成
+    const roomId = crypto.randomUUID();
+    router.push(`/room/${roomId}/map`);
+  };
+
+  return (
+    <Button
+      onClick={handleCreateRoom}
+      className="h-[42px] w-full max-w-[265px] rounded-[12px] border-2 border-white bg-rose-500 text-[20px] font-normal text-white hover:bg-rose-500 hover:opacity-90"
+    >
+      ルーム作成
+    </Button>
+  );
+}

--- a/src/features/scan/components/RescanQRButton.tsx
+++ b/src/features/scan/components/RescanQRButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 
 import { Button } from "@/shared/components/ui/button";

--- a/src/features/scan/components/RescanQRButton.tsx
+++ b/src/features/scan/components/RescanQRButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/shared/components/ui/button";
+
+export default function RescanQRButton() {
+  return (
+    <Button
+      asChild
+      className="h-[42px] w-full max-w-[265px] rounded-[12px] border-2 border-white bg-rose-500 text-[20px] font-normal text-white hover:bg-rose-500 hover:opacity-90"
+    >
+      <Link href="/scan/location">QRコード読み直し</Link>
+    </Button>
+  );
+}


### PR DESCRIPTION
# Pull Request

## 関連Issue

<!-- 関連するIssue番号を記載してください。例: #10 -->

- closes #35 

## 変更理由

  QRコードスキャン後の操作性向上のため、以下の2つのボタンコンポーネントを実装しました。
  - QRコードの読み直しを行うボタン
  - 新しいルームを作成するボタン

## 変更内容

  - RescanQRButtonコンポーネントの追加
    - /scan/locationへ遷移するLinkボタン
    - ボタンテキスト: "QRコード読み直し"
  - CreateRoomButtonコンポーネントの追加
    - crypto.randomUUID()でUUID v4を生成
    - /room/[room_id]/mapへ遷移するボタン
    - ボタンテキスト: "ルーム作成"
  - 両ボタンの共通スタイル
    - 背景色: bg-rose-500
    - サイズ: h-[42px] w-full max-w-[265px]
    - ボーダー: border-2 border-white
    - 角丸: rounded-[12px]

 ## 変更箇所

  - src/features/scan/components/RescanQRButton.tsx (新規作成)
  - src/features/scan/components/CreateRoomButton.tsx (新規作成)

 ## 注意事項

  - ルームIDは現在UUID v4のハードコーディングで実装されています（仕様通り）
  - これらのコンポーネントは別ページで使用される予定のため、index.tsへのエクスポートは行っていません
  - /room/[room_id]/mapのルートが存在することを前提としています

- [x] Lintチェック
- [x] 動作確認
