### PR TITLE
feat: マッチング成功モーダルにスピナーを追加

### DIFF
--- a/src/features/room/components/MatchingSuccessModal.tsx
+++ b/src/features/room/components/MatchingSuccessModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Spinner } from "@/shared/components/ui/spinner";
 import { ONE_SECOND_MS } from "@/shared/constants/time";
 import { useAutoClose } from "@/shared/hooks";
 
@@ -20,7 +21,12 @@ export function MatchingSuccessModal({ open, onClose }: MatchingSuccessModalProp
       open={open}
       onClose={onClose}
       title="マッチングが成立しました！"
-      footer={<p className="text-base text-black font-normal">最適な目的地・経路を考え中です...</p>}
+      footer={
+        <div className="flex items-center gap-2 text-base text-black font-normal">
+          <Spinner className="size-5" />
+          <p>最適な目的地・経路を考え中です...</p>
+        </div>
+      }
     />
   );
 }

--- a/src/shared/components/ui/spinner.tsx
+++ b/src/shared/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };


### PR DESCRIPTION
# Pull Request

## 関連Issue

- closes #27

## 変更理由

マッチング成功後、バックエンドから通信があるまでモーダルが開いたままになる設計を予定しています。現在の実装では、最適な目的地・経路を考え中であることがテキストのみでしか表現されておらず、ユーザーが処理中であることを視覚的に理解しにくい状態でした。そのため、処理中であることを明確に示すスピナーを追加しました。

## 変更内容

- shadcn/ui の Spinner コンポーネントを追加
- [MatchingSuccessModal](cci:1://file:///Users/giga/Documents/d-navi-frontend/src/features/room/components/MatchingSuccessModal.tsx:15:0-31:1) のフッター部分にスピナーを表示
- スピナーとテキストを横並び(flex)レイアウトで配置
- 適切なサイズ調整とスペーシングを実装

## 変更箇所

- [src/shared/components/ui/spinner.tsx](cci:7://file:///Users/giga/Documents/d-navi-frontend/src/shared/components/ui/spinner.tsx:0:0-0:0) (新規追加)
  - shadcn/ui の Spinner コンポーネント
  - Lucide React の Loader2Icon をベースにしたアニメーション
- [src/features/room/components/MatchingSuccessModal.tsx](cci:7://file:///Users/giga/Documents/d-navi-frontend/src/features/room/components/MatchingSuccessModal.tsx:0:0-0:0)
  - Spinner コンポーネントのインポート追加
  - footer プロップを更新してスピナーを表示

## 注意事項

- スピナーはモーダルが開いている間、継続的にアニメーションします
- 将来的にバックエンドからの通信でモーダルを自動的に閉じる実装を予定しているため、その際の動作確認をお願いします
- インポート順序は ESLint の import/order ルールに準拠しています

- [x] Lintチェック
- [ ] 動作確認