### PR TITLE
feat: ナビ案内画面の実装

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -8,7 +8,7 @@ export default function MainLayout({
   return (
     <>
       <Header />
-      {children}
+      <main className="mt-12">{children}</main>
     </>
   );
 }

--- a/src/app/(main)/room/[room_id]/meet/page.tsx
+++ b/src/app/(main)/room/[room_id]/meet/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next";
+
+import RouteGuidanceContainer from "@/features/map/components/RouteGuidanceContainer";
+
+export const metadata: Metadata = {
+  title: "ナビ案内",
+};
+
+export default function Meet() {
+  return <RouteGuidanceContainer />;
+}

--- a/src/features/map/components/RouteGuidanceContainer.tsx
+++ b/src/features/map/components/RouteGuidanceContainer.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Map } from "@/features/map/components/Map";
+import RescanQRButton from "@/features/scan/components/RescanQRButton";
+
+export default function RouteGuidanceContainer() {
+  return (
+    <div className="flex flex-col justify-center items-center gap-12">
+      <Map />
+      <RescanQRButton />
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request

## 関連Issue

- closes #39

## 変更理由

ユーザーが目的地までのナビゲーションを受けられるようにするため、ナビ案内画面を実装しました。

## 変更内容

- `RouteGuidanceContainer.tsx`: ナビ案内のメインコンテナコンポーネント
  - Mapコンポーネントでフロアマップを表示
  - RescanQRButtonでQRコード再スキャン機能を提供
  
- `page.tsx`: ナビ案内ページの実装
  - メタデータ設定（title: "ナビ案内"）
  - RouteGuidanceContainerのマウント

## 変更箇所

- `src/app/(main)/room/[room_id]/meet/page.tsx`
- `src/features/map/components/RouteGuidanceContainer.tsx`
- `src/app/(main)/layout.tsx`

## 注意事項

- [x] Lintチェック
- [x] 動作確認